### PR TITLE
Fix a problem where processes are not killed for timeout

### DIFF
--- a/snowchains_core/CHANGELOG.md
+++ b/snowchains_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed [a problem where processes are not killed for timeout](https://github.com/qryxip/cargo-compete/issues/135).
+
 ## [0.9.1] - 2021-02-18Z
 
 ### Fixed

--- a/snowchains_core/src/judge.rs
+++ b/snowchains_core/src/judge.rs
@@ -541,7 +541,7 @@ pub fn judge<C: 'static + Future<Output = tokio::io::Result<()>> + Send>(
                     {
                         status?
                     } else {
-                        let _ = child.kill();
+                        let _ = child.kill().await;
                         let verdict = Verdict::TimelimitExceeded {
                             test_case_name,
                             timelimit,


### PR DESCRIPTION
For qryxip/cargo-compete#135.
