### PR TITLE
Accept "Ex" problems of ABC

### DIFF
--- a/snowchains_core/CHANGELOG.md
+++ b/snowchains_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Accepts "Ex" problems of ABC.
+
 ## [0.13.1] - 2021-12-28Z
 
 ### Fixed

--- a/snowchains_core/src/web/mod.rs
+++ b/snowchains_core/src/web/mod.rs
@@ -939,13 +939,6 @@ impl CaseConvertion for LowerCase {
     const CONVERT: fn(&str) -> String = str::to_lowercase;
 }
 
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-enum UpperCase {}
-
-impl CaseConvertion for UpperCase {
-    const CONVERT: fn(&str) -> String = str::to_uppercase;
-}
-
 #[ext(ResponseExt)]
 impl reqwest::blocking::Response
 where


### PR DESCRIPTION
For qryxip/cargo-compete#184.

```console
❯ cargo compete n abc234
     Created `abc234` package at /home/ryo/src/competitive/atcoder/./abc234
       Saved 3 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{a.yml, a/}
       Saved 2 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{b.yml, b/}
       Saved 3 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{c.yml, c/}
       Saved 2 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{d.yml, d/}
       Saved 3 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{e.yml, e/}
       Saved 3 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{f.yml, f/}
       Saved 3 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{g.yml, g/}
       Saved 3 test cases to /home/ryo/src/competitive/atcoder/./abc234/testcases/{ex.yml, ex/}
❯ cat ./abc234/Cargo.toml | head -n 18 | tail -n 9
[package.metadata.cargo-compete.bin]
abc234-a = { alias = "a", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_a" }
abc234-b = { alias = "b", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_b" }
abc234-c = { alias = "c", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_c" }
abc234-d = { alias = "d", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_d" }
abc234-e = { alias = "e", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_e" }
abc234-ex = { alias = "ex", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_h" }
abc234-f = { alias = "f", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_f" }
abc234-g = { alias = "g", problem = "https://atcoder.jp/contests/abc234/tasks/abc234_g" }
❯ tree ./abc234/src/bin
./abc234/src/bin
├── a.rs
├── b.rs
├── c.rs
├── d.rs
├── e.rs
├── ex.rs
├── f.rs
└── g.rs

0 directories, 8 files
❯ cat ./abc234/testcases/ex.yml
---
type: Batch
timelimit: 4s
match: Lines

cases:
  - name: sample1
    in: |
      6 5
      2 0
      2 2
      3 4
      0 0
      5 5
      8 3
    out: |
      9
      1 2
      1 3
      1 4
      2 3
      2 4
      2 5
      3 4
      3 5
      5 6
  - name: sample2
    in: |
      2 1414213562
      0 0
      1000000000 1000000000
    out: |
      0
  - name: sample3
    in: |
      10 150
      300 300
      300 400
      300 500
      400 300
      400 400
      400 400
      400 500
      500 300
      500 400
      500 500
    out: |
      29
      1 2
      1 4
      1 5
      1 6
      2 3
      2 4
      2 5
      2 6
      2 7
      3 5
      3 6
      3 7
      4 5
      4 6
      4 8
      4 9
      5 6
      5 7
      5 8
      5 9
      5 10
      6 7
      6 8
      6 9
      6 10
      7 9
      7 10
      8 9
      9 10

extend:
  - type: Text
    path: "./ex"
    in: /in/*.txt
    out: /out/*.txt
```
